### PR TITLE
Dependencies building order fix and PATH override for libgpg-error.

### DIFF
--- a/scripts/macosx/modules/build_dependencies.module.sh
+++ b/scripts/macosx/modules/build_dependencies.module.sh
@@ -36,8 +36,8 @@ DEP_ZLIB_URL="http://zlib.net/${DEP_ZLIB_FILE}"
 function build_dependencies() {
     log "Building dependencies..."
     build_openssl
-    _build_dep_default "libgcrypt" "${DEP_LIBGCRYPT_VER}" "${DEP_LIBGCRYPT_FILE}" "${DEP_LIBGCRYPT_URL}" "libgcrypt.20.dylib"
     _build_dep_default "libgpg-error" "${DEP_LIBGPGERROR_VER}" "${DEP_LIBGPGERROR_FILE}" "${DEP_LIBGPGERROR_URL}" "libgpg-error.0.dylib"
+    _build_dep_default "libgcrypt" "${DEP_LIBGCRYPT_VER}" "${DEP_LIBGCRYPT_FILE}" "${DEP_LIBGCRYPT_URL}" "libgcrypt.20.dylib"
     _build_dep_default "libidn" "${DEP_LIBIDN_VER}" "${DEP_LIBIDN_FILE}" "${DEP_LIBIDN_URL}" "libidn.11.dylib"
     _build_dep_default "zlib" "${DEP_ZLIB_VER}" "${DEP_ZLIB_FILE}" "${DEP_ZLIB_URL}" "libz.${DEP_ZLIB_VER}.dylib"
     build_minizip

--- a/scripts/macosx/modules/check_environment.module.sh
+++ b/scripts/macosx/modules/check_environment.module.sh
@@ -77,6 +77,8 @@ as normal user!"
 
     # Prepare PKG_CONFIG_PATH.
     export PKG_CONFIG_PATH="${DEPS_ROOT}/lib/pkgconfig:${PKG_CONFIG_PATH}"
+    # Use tools from DEPS_ROOT/bin directory (notable gpg-error).
+    export PATH="${DEPS_ROOT}/bin:${PATH}"
 
     # Compiler options.
     export MACOSX_DEPLOYMENT_TARGET=10.9


### PR DESCRIPTION
Fixed dependencies building by moving libgpg-error building before
libgcrypt.

Added PATH override for proper libgpg-error detection - we should
not use libgpg-error provided by brew, because this cause qca-gcrypt
failing.